### PR TITLE
Add support for Aidoo Pro device (similar fix to Issue #18)

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -143,7 +143,7 @@ export class AirzoneCloudHomebridgePlatform implements DynamicPlatformPlugin {
         for (const group of installation!.groups || []) {
           this.log.debug(`Group: ${group.name}<${group.group_id}>`);
           for (const device of group.devices || []) {
-            if (device.type === 'az_zone' || device.type === 'aidoo') {
+            if (device.type === 'az_zone' || device.type === 'aidoo' || device.type === 'aidoo_it') {
               this.log.debug(`AirZone Device: ${device.name}<${device.device_id}>`);
               const webserverStatus = webservers[device.ws_id] ||
                 await this.airzoneCloudApi.getWebserverStatus(installation!.installation_id, device.ws_id);


### PR DESCRIPTION
Hello!

I recently installed an Airzone Aidoo Pro device with my HVAC system and then separately installed your Airzone Cloud plugin for Homebridge so I could ideally control my HVAC system through HomeKit. However, I seem to be running into the exact same problem as described in Issue #18 where even though the plugin loads, authenticates with the m.airzonecloud.com, enumerates my account/devices, and shows there are no issues, no Airzone Cloud accessories or devices ever enumerate in the HomeKit accessory list for use. 

From examining debug output in the Homebridge logs and your prior changelist in version 0.3.0 which fixed #18 by adding aidoo support, I believe the issue is that support for Aidoo Pro needs to similarly be added since it has a different device_type ("aidoo_it") than a non-pro Aidoo device ("aidoo"). You can see this different device_type coming back from the airzone service during the GET call for installation details and device_state in this redacted snippet from my homebridge log that I've included here:

> ...(snip)...
> [12/18/2022, 4:20:19 PM] [AirzoneCloud] [Websocket] ⬆ ["clear_listeners"]
> [12/18/2022, 4:20:19 PM] [AirzoneCloud] Cleaned cached installationId and webserverId
> [12/18/2022, 4:20:19 PM] [AirzoneCloud] [Websocket] ⬇ [null]
> [12/18/2022, 4:20:19 PM] [AirzoneCloud] [Websocket] ⬆ ["listen_installation", "XXX"]
> [12/18/2022, 4:20:20 PM] [AirzoneCloud] [Websocket] ⬇ [null]
> [12/18/2022, 4:20:20 PM] [AirzoneCloud] [Websocket] ⬇ ["DEVICE_STATE",{"device_id":"XXX",**"device_type":"aidoo_it"**,"ws_id":"XXX","status":{"isConnected":true,"connection_date":"2022-11-19T05:21:43.962Z","disconnection_date":"2022-11-19T05:35:36.612Z","ws_connected":true,"machineready":true, ...}
> ...(snip)...

This proposed change is is to add support for the Aidoo Pro device_type ('aidoo_it'). Would it be possible to accept and publish this change as a new version of the plug-in so I can get the Homebridge plug-in working with my Aidoo Pro installation?

Thanks for your consideration and all of your work on this plug-in! Hopefully this change can help someone else who is using this plug-in with an Aidoo Pro device.