### PR TITLE
check to first make sure the temp name exists in the device status

### DIFF
--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -222,7 +222,7 @@ export class AirzoneCloudPlatformAccessory {
     const startTime = Date.now().valueOf();
     // TargetTemperature => Min Value 10, Max Value 38, Min Step 0.1
     await this.refresh();
-    const setpointTemperature = this.device.status.power ?
+    const setpointTemperature = (this.device.status.power && this.device.status.hasOwnProperty(this.getTargetTempertureName())) ?
       this.device.status[this.getTargetTempertureName()] : this.device.status.setpoint_air_stop || this.device.status.setpoint_air_auto;
     const targetTemperature = this.device.status.units ? setpointTemperature.fah : setpointTemperature.celsius;
 


### PR DESCRIPTION
When in vent mode the target temp name is "setpoint_air_vent", however that does not exist in the device.status. This checks to make sure it's in device.status before trying to get it. If we don't do this we will throw an error